### PR TITLE
feat: Integrate MongoDB Atlas Serverless in example module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .terraform
 
-examples/basic/.terraform
-examples/basic/terraform.tfstate*
-examples/basic/credentials.tf
+examples/*/.terraform
+examples/*/terraform.tfstate*
+examples/*/.terraform.tfstate.lock.info
+examples/*/terraform.tfvars
+examples/*/credentials.tf

--- a/examples/basic/.terraform.lock.hcl
+++ b/examples/basic/.terraform.lock.hcl
@@ -39,3 +39,25 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
   ]
 }
+
+provider "registry.terraform.io/mongodb/mongodbatlas" {
+  version     = "1.10.2"
+  constraints = "~> 1.10.2"
+  hashes = [
+    "h1:gV1NyOyfojYIebM43NogJzP0ykqoIDH8ZHmFAijqnhc=",
+    "zh:15764df81009e88970a2757b9b7f5fd76800692e848d396aef56c0bff0481b45",
+    "zh:17cc558fa232dc2c891cce52d5c54949d8535fb07826181e2c382e3f60a223af",
+    "zh:25e09be6ea5ddf092e7670b54e4c0585b7566d1a66e4fa2aadeacd2641f614d3",
+    "zh:4bd82c20c4d4b98218400cc6775bd63aa5e3fd04006b4198dcdf7834a19120b2",
+    "zh:5985ef8e90aa9e2e6eebaf9fdfea7285265c761ad19b1cb5c8a96503de626c97",
+    "zh:59cf0ac004de2d59e55a0e39d7c5a6d26d46d2dba09502900d7cc4b43fae7ff7",
+    "zh:5e3ca99e1b29f2dc20ca130f68d70a68e5b9bd9f2d1e14fbe4195c20076d23a3",
+    "zh:a1a9c474eb371177db982e7d91d828d561adb403a8637e275b92765d43829964",
+    "zh:a3fb68525780e7d4b2a75102baed9317bc6c300c7d44ed2e5b9dafeb84fb5156",
+    "zh:b87127a1d902c5ed41588a8a28bb10888f56f2601aab9fb75f6e8e7045b3bb9e",
+    "zh:c7bcd104e6c8f16fc9da1e89b35a36113328963f01303f89a9a9f9776164b679",
+    "zh:d6a6d50fe61fb65167f054a86e480697a3c28e8c21feb85422f6f190f4b7df26",
+    "zh:fe1ddbb40944c9c023637bde33b05ce524de16ed9d060deaa2e19688e5949ccb",
+    "zh:fe66ac9f180e8d5893c7e823e2b0f623b7d6e038ec1db8a919ca206e7a0d0ff3",
+  ]
+}

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,1 +1,5 @@
 # Example module
+
+## Limitations
+
+- This module does NOT restrict access to MongoDB from any particular IP address.

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -9,5 +9,10 @@ module "self" {
   project_id = local.project_id
   region     = local.gcp_region
 
+  mongodb_uri = mongodbatlas_serverless_instance.main.connection_strings_standard_srv
+
+  mongodb_user                    = mongodbatlas_database_user.main.username
+  mongodb_password_secret_version = google_secret_manager_secret_version.mongodb_password.id
+
   depends_on = [google_project_service.services]
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,12 +1,13 @@
 locals {
   project_id = "tmp-tf-awala-endpoint"
+  gcp_region = "europe-west1"
 }
 
 module "self" {
   source = "../.."
 
   project_id = local.project_id
-  region     = "europe-west1"
+  region     = local.gcp_region
 
   depends_on = [google_project_service.services]
 }

--- a/examples/basic/mongodb.tf
+++ b/examples/basic/mongodb.tf
@@ -1,3 +1,7 @@
+locals {
+  mongodb_db_name = "main"
+}
+
 resource "mongodbatlas_serverless_instance" "main" {
   project_id = var.mongodbatlas_project_id
   name       = "awala-endpoint"
@@ -5,4 +9,40 @@ resource "mongodbatlas_serverless_instance" "main" {
   provider_settings_backing_provider_name = "GCP"
   provider_settings_provider_name         = "SERVERLESS"
   provider_settings_region_name           = "WESTERN_EUROPE"
+}
+
+resource "mongodbatlas_database_user" "main" {
+  project_id = var.mongodbatlas_project_id
+
+  username           = "awala-endpoint"
+  password           = random_password.mongodb_user_password.result
+  auth_database_name = "admin"
+
+  roles {
+    role_name     = "readWrite"
+    database_name = mongodbatlas_serverless_instance.main.name
+  }
+}
+
+resource "random_password" "mongodb_user_password" {
+  length = 32
+}
+
+resource "google_secret_manager_secret" "main" {
+  project = local.project_id
+
+  secret_id = "awala_endpoint-mongodb_password"
+
+  replication {
+    user_managed {
+      replicas {
+        location = local.gcp_region
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_version" "main" {
+  secret      = google_secret_manager_secret.main.id
+  secret_data = random_password.mongodb_user_password.result
 }

--- a/examples/basic/mongodb.tf
+++ b/examples/basic/mongodb.tf
@@ -28,7 +28,7 @@ resource "random_password" "mongodb_user_password" {
   length = 32
 }
 
-resource "google_secret_manager_secret" "main" {
+resource "google_secret_manager_secret" "mongodb_password" {
   project = local.project_id
 
   secret_id = "awala_endpoint-mongodb_password"
@@ -42,12 +42,18 @@ resource "google_secret_manager_secret" "main" {
   }
 }
 
-resource "google_secret_manager_secret_version" "main" {
-  secret      = google_secret_manager_secret.main.id
+resource "google_secret_manager_secret_version" "mongodb_password" {
+  secret      = google_secret_manager_secret.mongodb_password.id
   secret_data = random_password.mongodb_user_password.result
 }
 
 resource "mongodbatlas_project_ip_access_list" "test" {
   project_id = var.mongodbatlas_project_id
   cidr_block = "0.0.0.0/0"
+}
+
+resource "google_secret_manager_secret_iam_binding" "mongodb_password_reader" {
+  secret_id = google_secret_manager_secret.mongodb_password.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  members   = ["serviceAccount:${module.self.service_account_email}"]
 }

--- a/examples/basic/mongodb.tf
+++ b/examples/basic/mongodb.tf
@@ -46,3 +46,8 @@ resource "google_secret_manager_secret_version" "main" {
   secret      = google_secret_manager_secret.main.id
   secret_data = random_password.mongodb_user_password.result
 }
+
+resource "mongodbatlas_project_ip_access_list" "test" {
+  project_id = var.mongodbatlas_project_id
+  cidr_block = "0.0.0.0/0"
+}

--- a/examples/basic/mongodb.tf
+++ b/examples/basic/mongodb.tf
@@ -1,0 +1,8 @@
+resource "mongodbatlas_serverless_instance" "main" {
+  project_id   = var.mongodbatlas_project_id
+  name         = "awala-endpoint"
+
+  provider_settings_backing_provider_name = "GCP"
+  provider_settings_provider_name = "SERVERLESS"
+  provider_settings_region_name = "WESTERN_EUROPE"
+}

--- a/examples/basic/mongodb.tf
+++ b/examples/basic/mongodb.tf
@@ -1,8 +1,8 @@
 resource "mongodbatlas_serverless_instance" "main" {
-  project_id   = var.mongodbatlas_project_id
-  name         = "awala-endpoint"
+  project_id = var.mongodbatlas_project_id
+  name       = "awala-endpoint"
 
   provider_settings_backing_provider_name = "GCP"
-  provider_settings_provider_name = "SERVERLESS"
-  provider_settings_region_name = "WESTERN_EUROPE"
+  provider_settings_provider_name         = "SERVERLESS"
+  provider_settings_region_name           = "WESTERN_EUROPE"
 }

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+      version = "~> 1.10.2"
+    }
+  }
+}
+
+provider "mongodbatlas" {
+  public_key = var.mongodbatlas_public_key
+  private_key  = var.mongodbatlas_private_key
+}

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "mongodbatlas" {
-  public_key = var.mongodbatlas_public_key
-  private_key  = var.mongodbatlas_private_key
+  public_key  = var.mongodbatlas_public_key
+  private_key = var.mongodbatlas_private_key
 }

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -1,0 +1,9 @@
+variable "mongodbatlas_public_key" {
+    description = "MongoDB Atlas public key"
+}
+
+variable "mongodbatlas_private_key" {
+    description = "MongoDB Atlas private key"
+}
+
+variable "mongodbatlas_project_id" {}

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -1,9 +1,9 @@
 variable "mongodbatlas_public_key" {
-    description = "MongoDB Atlas public key"
+  description = "MongoDB Atlas public key"
 }
 
 variable "mongodbatlas_private_key" {
-    description = "MongoDB Atlas private key"
+  description = "MongoDB Atlas private key"
 }
 
 variable "mongodbatlas_project_id" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "service_account_email" {
+  value = google_service_account.endpoint.email
+}

--- a/variables.tf
+++ b/variables.tf
@@ -18,3 +18,18 @@ variable "kms_protection_level" {
     error_message = "KMS protection level must be either SOFTWARE or HSM"
   }
 }
+
+variable "mongodb_uri" {
+  description = "The MongoDB URI"
+  type        = string
+}
+
+variable "mongodb_user" {
+  description = "The MongoDB username"
+  type        = string
+}
+
+variable "mongodb_password_secret_version" {
+  description = "The id of the Secrets Manager secret version containing the MongoDB password"
+  type        = string
+}


### PR DESCRIPTION
- [x] Create user
- [x] Restrict access from europe-west1 IP addresses.
- [x] Create Secrets Manager secret containing connection URL.