### PR TITLE
fix: Implement workaround to make HSM keys work

### DIFF
--- a/bootstrap.tf
+++ b/bootstrap.tf
@@ -55,11 +55,11 @@ resource "google_cloud_run_v2_job" "bootstrap" {
 
         env {
           name  = "ACTIVE_ID_KEY_REF"
-          value = google_kms_crypto_key_version.identity_key.id
+          value = data.google_kms_crypto_key_version.initial_identity_key.id
         }
         env {
           name  = "ACTIVE_ID_PUBLIC_KEY"
-          value = data.google_kms_crypto_key_version.identity_key.public_key[0].pem
+          value = data.google_kms_crypto_key_version.initial_identity_key.public_key[0].pem
         }
 
         env {

--- a/pohttp_client.tf
+++ b/pohttp_client.tf
@@ -52,11 +52,11 @@ resource "google_cloud_run_v2_service" "pohttp_client" {
 
       env {
         name  = "ACTIVE_ID_KEY_REF"
-        value = google_kms_crypto_key_version.identity_key.id
+        value = data.google_kms_crypto_key_version.initial_identity_key.id
       }
       env {
         name  = "ACTIVE_ID_PUBLIC_KEY"
-        value = data.google_kms_crypto_key_version.identity_key.public_key[0].pem
+        value = data.google_kms_crypto_key_version.initial_identity_key.public_key[0].pem
       }
 
       env {

--- a/pohttp_server.tf
+++ b/pohttp_server.tf
@@ -52,11 +52,11 @@ resource "google_cloud_run_v2_service" "pohttp_server" {
 
       env {
         name  = "ACTIVE_ID_KEY_REF"
-        value = google_kms_crypto_key_version.identity_key.id
+        value = data.google_kms_crypto_key_version.initial_identity_key.id
       }
       env {
         name  = "ACTIVE_ID_PUBLIC_KEY"
-        value = data.google_kms_crypto_key_version.identity_key.public_key[0].pem
+        value = data.google_kms_crypto_key_version.initial_identity_key.public_key[0].pem
       }
 
       env {


### PR DESCRIPTION
We can't explicitly create key versions with Google KMS due to https://github.com/hashicorp/terraform-provider-google/issues/13924, so this change lets the `google_kms_crypto_key` resource create an initial key and then we import it.
